### PR TITLE
This is more effective approach to handle scaling down events

### DIFF
--- a/samples/stable-diffusion/manifests/app-gpu.yaml
+++ b/samples/stable-diffusion/manifests/app-gpu.yaml
@@ -21,7 +21,7 @@ spec:
         name: stable-diffusion-worker
         imagePullPolicy: IfNotPresent
         resources:
-          # uncomment if you want one GPU exclusively for this app, otherwise the GPU will be shared among many
+          # uncomment if you want one GPU exclusively for this app, otherwise the GPU will be shared among many (gpu slicing)
           # limits:
           #   nvidia.com/gpu: "1"
           requests:
@@ -58,10 +58,11 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
         - |
+          trap 'while [ -f "/images/working" ]; do sleep 1; done; sleep 5' SIGTERM
           mc alias set shared http://minio:9000 $MINIO_USERNAME $MINIO_PASSWORD;
           mc admin info shared;
           echo "Minio configured, starting sync.."
-          mc mirror --watch /images shared/images;
+          mc mirror --exclude working --watch /images shared/images;
 
         volumeMounts:
         - name: shared-images
@@ -79,3 +80,4 @@ spec:
       volumes:
       - name: shared-images
         emptyDir: {}
+      terminationGracePeriodSeconds: 120

--- a/samples/stable-diffusion/manifests/app.yaml
+++ b/samples/stable-diffusion/manifests/app.yaml
@@ -53,10 +53,11 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
         - |
+          trap 'while [ -f "/images/working" ]; do sleep 1; done; sleep 5' SIGTERM
           mc alias set shared http://minio:9000 $MINIO_USERNAME $MINIO_PASSWORD;
           mc admin info shared;
           echo "Minio configured, starting sync.."
-          mc mirror --watch /images shared/images;
+          mc mirror --exclude working --watch /images shared/images;
 
         volumeMounts:
         - name: shared-images
@@ -74,3 +75,4 @@ spec:
       volumes:
       - name: shared-images
         emptyDir: {}
+      terminationGracePeriodSeconds: 120

--- a/samples/stable-diffusion/manifests/scaledjob.yaml
+++ b/samples/stable-diffusion/manifests/scaledjob.yaml
@@ -63,7 +63,7 @@ spec:
             echo "Minio configured, waiting for the result.."
             until [ -f /images/*.png ] && [ -f /images/*.json ]; do sleep 1; printf .; done
             echo -e "\nResults have been found: \n$(ls /images)\nSyncing.."
-            mc mirror /images shared/images;
+            mc mirror --exclude working /images shared/images;
 
           volumeMounts:
           - name: shared-images

--- a/samples/stable-diffusion/manifests/scaledobject.yaml
+++ b/samples/stable-diffusion/manifests/scaledobject.yaml
@@ -16,16 +16,16 @@ spec:
   scaleTargetRef:
     name: stable-diffusion-worker
   pollingInterval: 10
-  cooldownPeriod: 300
+  cooldownPeriod: 150
   minReplicaCount: 0
   maxReplicaCount: 8
   advanced:
     horizontalPodAutoscalerConfig:
       behavior:
         scaleUp:
-          stabilizationWindowSeconds: 15
+          stabilizationWindowSeconds: 5
         scaleDown:
-          stabilizationWindowSeconds: 15
+          stabilizationWindowSeconds: 150
   triggers:
     # https://keda.sh/docs/2.14/scalers/rabbitmq-queue/
     - type: rabbitmq

--- a/samples/stable-diffusion/manifests/webapp.yaml
+++ b/samples/stable-diffusion/manifests/webapp.yaml
@@ -78,7 +78,7 @@ spec:
           mc alias set shared http://minio:9000 $MINIO_USERNAME $MINIO_PASSWORD
           mc admin info shared
           echo "Minio configured, starting sync.."
-          while true; do mc mirror --overwrite shared/images /images; sleep 1; done
+          while true; do mc mirror --exclude working --overwrite shared/images /images; sleep 1; done
 
         volumeMounts:
         - name: shared-images


### PR DESCRIPTION
minio side-car containers needs to wait for the main container to write the image on fs and sync it before being killed. Since we already share the directory on the pod, we introduce a file that synchronizes these two processes.

Other approach would be to use shared PID namespace (`podspec. shareProcessNamespace=true`) and check if the python process is running, but that would lead to weaker security.

also giving a container enough time to finish the task `terminationGracePeriodSeconds=120`. When one pod is working (having the whole GPU for itself), it finishes around 32 seconds. However, when multiple worker pods share the GPU at the same time the time goes up (I'd say linearly, but don't have numbers).