### PR TITLE
stable-diff: add pre-stop hook that kills amqp-consume that runs in a…

### DIFF
--- a/samples/stable-diffusion/manifests/app-gpu.yaml
+++ b/samples/stable-diffusion/manifests/app-gpu.yaml
@@ -27,6 +27,10 @@ spec:
           requests:
             cpu: 500m
             memory: 1Gi
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh","-c","/usr/bin/pkill amqp-consume; /usr/bin/pkill sleep"]
         volumeMounts:
         - name: shared-images
           mountPath: /app/results

--- a/samples/stable-diffusion/manifests/app.yaml
+++ b/samples/stable-diffusion/manifests/app.yaml
@@ -33,6 +33,10 @@ spec:
           requests:
             cpu: "1"
             memory: 1Gi
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh","-c","/usr/bin/pkill amqp-consume; /usr/bin/pkill sleep"]
       - image: minio/mc
         name: minio-sidecar
         env:


### PR DESCRIPTION
… blocking fashion as a forward process so that trap can't be used to forward the signal