### PR TITLE
grpc-responder: use GRPCS backned protocol for nginx ingress when TLS enabled

### DIFF
--- a/samples/grpc-responder/config/ingress-tls.yaml
+++ b/samples/grpc-responder/config/ingress-tls.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: grpc-responder
   annotations:
-    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    nginx.ingress.kubernetes.io/backend-protocol: "GRPCS"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
     nginx.ingress.kubernetes.io/proxy-http-version: "1.1"


### PR DESCRIPTION
otherwise nginx responds TLS/HTTP1.1 with 502
```
$ grpcurl -d '{"name": "Test"}' -vv -authority grpc.keda -cacert server.crt 172.18.255.200:443 responder.HelloService/SayHello
Error invoking method "responder.HelloService/SayHello": rpc error: code = Unavailable desc = failed to query for service descriptor "responder.HelloService": unexpected HTTP status code received from server: 502 (Bad Gateway); transport: received unexpected content-type "text/html"
```
because it is trying to reach the backend with plaintext gRPC

see also: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#backend-protocol