### PR TITLE
killercoda: gRPC scaling tutorial

### DIFF
--- a/killercoda/grpc/assets/benchmark.sh
+++ b/killercoda/grpc/assets/benchmark.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function f() {
+    echo "Metrics from KEDA:"
+    kubectl get --raw '/api/v1/namespaces/keda/services/keda-add-ons-http-interceptor-admin:9090/proxy/queue' | jq -C '.'
+    echo ""
+    echo "Running pods:"
+    kubecolor --force-colors get po -ndefault
+    cat /tmp/ghz.output
+}
+export -f f
+
+trap "kill $(pidof ghz) 2>/dev/null; kill -SIGKILL $(pidof watch) 2>/dev/null" EXIT
+(
+  echo "" > /tmp/ghz.output
+  echo "" >> /tmp/ghz.output
+  echo "warming up the application" >> /tmp/ghz.output
+  grpcurl -d '{"name": "Test"}' --authority grpc.keda grpc.keda:443 responder.HelloService/SayHello > /dev/null 2>&1
+
+  echo "" > /tmp/ghz.output
+  echo "" >> /tmp/ghz.output
+  echo "running ghz benchmark" >> /tmp/ghz.output
+  echo "~10 req/sec" >> /tmp/ghz.output
+  ghz -z 5s --rps 10 --call responder.HelloService/SayHello -d '{"name": "Test"}' --authority grpc.keda grpc.keda:443 > /dev/null 2>&1
+  
+  echo "~20 req/sec" >> /tmp/ghz.output
+  ghz -z 5s --rps 20 --call responder.HelloService/SayHello -d '{"name": "Test"}' --authority grpc.keda grpc.keda:443 > /dev/null 2>&1
+  
+  echo "~30 req/sec" >> /tmp/ghz.output
+  ghz -z 5s --rps 30 --call responder.HelloService/SayHello -d '{"name": "Test"}' --authority grpc.keda grpc.keda:443 > /dev/null 2>&1
+
+  echo "~40 req/sec" >> /tmp/ghz.output
+  ghz -z 5s --rps 40 --call responder.HelloService/SayHello -d '{"name": "Test"}' --authority grpc.keda grpc.keda:443 > /dev/null 2>&1
+
+  echo "~50 req/sec" >> /tmp/ghz.output
+  ghz -z 5s --rps 50 --call responder.HelloService/SayHello -d '{"name": "Test"}' --authority grpc.keda grpc.keda:443 > /dev/null 2>&1
+  
+  echo "~60 req/sec" >> /tmp/ghz.output
+  ghz -z 5s --rps 60 --call responder.HelloService/SayHello -d '{"name": "Test"}' --authority grpc.keda grpc.keda:443 > /dev/null 2>&1
+
+  echo "~70 req/sec" >> /tmp/ghz.output
+  ghz -z 5s --rps 70 --call responder.HelloService/SayHello -d '{"name": "Test"}' --authority grpc.keda grpc.keda:443 > /dev/null 2>&1
+  
+  echo "~80 req/sec" >> /tmp/ghz.output
+  ghz -z 5s --rps 80 --call responder.HelloService/SayHello -d '{"name": "Test"}' --authority grpc.keda grpc.keda:443 > /dev/null 2>&1
+  
+  echo "~90 req/sec" >> /tmp/ghz.output
+  ghz -z 5s --rps 90 --call responder.HelloService/SayHello -d '{"name": "Test"}' --authority grpc.keda grpc.keda:443 > /dev/null 2>&1
+  
+  echo "~100 req/sec" >> /tmp/ghz.output
+  ghz -z 5s --rps 100 --call responder.HelloService/SayHello -d '{"name": "Test"}' --authority grpc.keda grpc.keda:443 > /dev/null 2>&1
+  
+  echo "~30 req/sec" >> /tmp/ghz.output
+  ghz -z 10s --rps 30 --call responder.HelloService/SayHello -d '{"name": "Test"}' --authority grpc.keda grpc.keda:443 > /dev/null 2>&1
+ 
+  echo "~15 req/sec" >> /tmp/ghz.output
+  ghz -z 10s --rps 15 --call responder.HelloService/SayHello -d '{"name": "Test"}' --authority grpc.keda grpc.keda:443 > /dev/null 2>&1
+  
+  echo "~10 req/sec" >> /tmp/ghz.output
+  ghz -z 15s --rps 10 --call responder.HelloService/SayHello -d '{"name": "Test"}' --authority grpc.keda grpc.keda:443 > /dev/null 2>&1
+
+  echo "~5 req/sec" >> /tmp/ghz.output
+  ghz -z 30s --rps 5 --call responder.HelloService/SayHello -d '{"name": "Test"}' --authority grpc.keda grpc.keda:443 > /dev/null 2>&1
+
+  echo "" >> /tmp/ghz.output
+  echo "benchmark finished, press 'ctrl+c' to kill the watch loop" >> /tmp/ghz.output
+  echo "when you are done observing the application scale-in" >> /tmp/ghz.output
+)&
+watch --no-title -n1 --color -x bash -c "f"

--- a/killercoda/grpc/assets/init-kedify.service
+++ b/killercoda/grpc/assets/init-kedify.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Init Kedify
+
+[Service]
+Restart=on-failure
+RestartSec=1
+ExecStart=/bin/bash /scripts/init-kedify.sh

--- a/killercoda/grpc/assets/init-kedify.sh
+++ b/killercoda/grpc/assets/init-kedify.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+# get krew
+if [[ ! -f /usr/bin/kubectl-krew ]]; then
+    wget -O /tmp/krew.tar.gz https://github.com/kubernetes-sigs/krew/releases/download/v0.4.4/krew-linux_amd64.tar.gz
+    ( cd /tmp && tar -xzf krew.tar.gz )
+    mv /tmp/krew-linux_amd64 /usr/bin/kubectl-krew
+    kubectl krew install krew
+fi
+
+# install kedify plugin deps
+DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends bat curl figlet fzf yq jq hey -y
+if [[ ! -f /usr/bin/bat ]]; then
+    ln -s /usr/bin/batcat /usr/bin/bat
+fi
+if [[ ! -f /usr/bin/kubecolor ]]; then
+    wget -O /tmp/kubecolor.tar.gz https://github.com/hidetatz/kubecolor/releases/download/v0.0.25/kubecolor_0.0.25_Linux_x86_64.tar.gz
+    ( cd /tmp && tar -xzf kubecolor.tar.gz )
+    mv /tmp/kubecolor /usr/bin/kubecolor
+fi
+
+# install kedify plugin
+if [[ ! -f /.krew/bin/kubectl-kedify ]]; then
+    kubectl krew install --manifest-url=https://github.com/kedify/kubectl-kedify/raw/main/.krew.yaml
+    echo 'export PATH="/.krew/bin:$PATH"' >> ~/.bashrc
+fi
+
+echo "all done"

--- a/killercoda/grpc/assets/install-kube-deps.service
+++ b/killercoda/grpc/assets/install-kube-deps.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Install kube deps
+
+[Service]
+Restart=on-failure
+RestartSec=1
+ExecStart=/bin/bash /scripts/install-kube-deps.sh

--- a/killercoda/grpc/assets/install-kube-deps.sh
+++ b/killercoda/grpc/assets/install-kube-deps.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+export KUBECONFIG=/root/.kube/config
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14.5/config/manifests/metallb-native.yaml
+
+export CAROOT=/root/.local/share/mkcert
+wget -O /bin/mkcert https://github.com/FiloSottile/mkcert/releases/download/v1.4.3/mkcert-v1.4.3-linux-amd64
+chmod +x /bin/mkcert
+mkcert -install
+
+wget -O /tmp/grpcurl.tar.gz https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz
+tar -zxvf /tmp/grpcurl.tar.gz -C /tmp
+mv /tmp/grpcurl /bin/grpcurl
+chmod +x /bin/grpcurl
+
+wget -O /tmp/ghz.tar.gz https://github.com/bojand/ghz/releases/download/v0.120.0/ghz-linux-x86_64.tar.gz
+tar -xzvf /tmp/ghz.tar.gz -C /tmp
+mv /tmp/ghz /bin/ghz
+chmod +x /bin/ghz
+
+kubectl wait --for=condition=Available --namespace metallb-system deployment/controller --timeout=5m
+cat <<EOF | kubectl apply -f -
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: killercoda
+  namespace: metallb-system
+spec:
+  addresses:
+  - 172.30.255.200-172.30.255.250
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: killercoda
+  namespace: metallb-system
+EOF
+
+helm upgrade --install ingress-nginx ingress-nginx \
+  --repo https://kubernetes.github.io/ingress-nginx \
+  --namespace ingress-nginx --create-namespace
+
+echo "all done"

--- a/killercoda/grpc/autoscale.md
+++ b/killercoda/grpc/autoscale.md
@@ -1,0 +1,92 @@
+Using Kedify to scale your application based on gRPC traffic works pretty much the same as with regular HTTP traffic and is as simple as creating one Kubernetes manifest, `ScaledObject`{{}}.
+
+> If you are new to KEDA, you can read more about `ScaledObject`{{}} in the official docs https://keda.sh/docs/2.15/reference/scaledobject-spec
+
+The `ScaledObject`{{}} references the desired application and configures scaling parameters so KEDA knows how to scale it.
+```yaml
+cat << 'EOF' | kubectl apply -f -
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: grpc-responder
+  namespace: default
+spec:
+  maxReplicaCount: 5
+  minReplicaCount: 0
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 5
+  cooldownPeriod: 5
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: grpc-responder
+  triggers:
+  - metadata:
+      hosts: grpc.keda
+      pathPrefixes: /
+      port: "50051"
+      scalingMetric: requestRate
+      service: grpc-responder
+      targetValue: "10"
+      tlsSecretName: grpc-responder
+    metricType: AverageValue
+    type: kedify-http
+EOF
+```{{exec}}
+
+Lets take a look at the fields to better understand what will happen next:
+* `scaleTargetRef`{{}} - references the application `Deployment`{{}} "grpc-responder" deployed earlier
+* `minReplicaCount`{{}} - allows scaling to 0 when there is no traffic flowing to the application
+* `maxReplicaCount`{{}} - capping maximum number of `Pods`{{}} to 5
+* `triggers.type`{{}} - the `kedify-http`{{}} is a [Kedify HTTP scaler](https://kedify.io/scalers/http)
+* `triggers.metadata.hosts`{{}} - domain `grpc.keda`{{}} is matching the domain also configured in the `Ingress`{{}}
+* `triggers.metadata.scalingMetric`{{}} - metric `requestRate`{{}} triggers scaling by default based on the number of requests per second
+* `triggers.metadata.targetValue`{{}} - value `10`{{}} means that for each 10 requests per second, there will be a replica of the application
+* `triggers.metadata.tlsSecretName`{{}} - reference to a `Secret`{{}} containing TLS cert/key pair for end-to-end traffic encryption
+
+As soon as the `ScaledObject`{{}} is created, the Kedify agent autowiring will modify the application `Ingress`{{}} to route the requests through KEDA. This is achieved by lazily deploying `kedify-proxy`{{}} in the application namespace.
+
+```
+kubectl wait -ndefault --timeout=5m --for=condition=Available deployment/kedify-proxy
+kubectl wait -ndefault --timeout=5m --for=jsonpath='{.spec.rules[0].http.paths[0].backend.service.name}="kedify-proxy"' ingress/grpc-responder
+kubectl get -ndefault ingress grpc-responder -o json | jq '.spec.rules[].http.paths[].backend'
+```{{exec}}
+
+The `backend`{{}} referenced in the application `Ingress`{{}} is no longer `"grpc-responder"`{{}} but `"kedify-proxy"`{{}} instead. This means the network traffic is routed there first and then back to the application.
+
+> The `kedify-proxy`{{}} forms an [envoy proxy](https://www.envoyproxy.io/) fleet deployed/undeployed and configured dynamically by Kedify. It also forwards live metrics to KEDA for scaling. When using scale to 0, there is also one instance of centrally deployed reverse proxy called `interceptor`{{}}. This `interceptor`{{}} is a component from [HTTP Add-on](https://github.com/kedacore/http-add-on) used for caching requests during application cold starts.
+
+You can observe the scaling metrics directly from KEDA using `kubectl`{{}}
+```bash
+kubectl get --raw '/api/v1/namespaces/keda/services/keda-add-ons-http-interceptor-admin:9090/proxy/queue' | jq '.'
+```{{exec}}
+
+Right now you should see that our configured metric `RPS`{{}} is `0`{{}}, that is because we made no requests to the application since it has been configured for autoscaling.
+```json
+{
+  "default/grpc-responder": {
+    "Concurrency": 0,
+    "RPS": 0
+  }
+}
+```{{}}
+
+There is a convenience benchmark script that can help you visualize scale-out and scale-in based on the number of requests flowing through KEDA.
+```
+/scripts/benchmark.sh
+```{{exec}}
+
+Whenever you are done with your observations, you can close the script with:
+```
+# ctrl+c
+```{{exec interrupt}}
+
+Congratulations! You have successfully configured gRPC autoscaling using Kedify, you can learn more about Kedify and check out our other courses at [https://kedify.io/tutorials](https://kedify.io/tutorials).
+
+&nbsp;
+&nbsp;
+
+##### 4 / 4

--- a/killercoda/grpc/background.sh
+++ b/killercoda/grpc/background.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+touch /tmp/progress
+(
+  echo "" >> /tmp/progress
+  echo "" >> /tmp/progress
+  echo "Please wait while we prepare your environment" >> /tmp/progress
+  sleep 8
+  echo "-- installing kubernetes apps " >> /tmp/progress
+  sleep 5
+  echo "-- installing Krew plugin manager " >> /tmp/progress
+  sleep 3
+  echo "-- installing dependencies " >> /tmp/progress
+  sleep 4
+  echo "-- installing Kedify tools " >> /tmp/progress
+  sleep 3
+  echo "-- finalizing environment " >> /tmp/progress
+)&
+systemctl start install-kube-deps.service
+systemctl start init-kedify.service --wait
+export PATH="/.krew/bin:$PATH"
+
+echo "-- ready" >> /tmp/progress

--- a/killercoda/grpc/deploy-sample-app-verify.sh
+++ b/killercoda/grpc/deploy-sample-app-verify.sh
@@ -1,0 +1,1 @@
+grpcurl -d '{"name": "Test"}' grpc.keda:443 responder.HelloService/SayHello

--- a/killercoda/grpc/deploy-sample-app.md
+++ b/killercoda/grpc/deploy-sample-app.md
@@ -1,0 +1,147 @@
+In this step, you will deploy an application - trivial [gRPC server](https://github.com/kedify/examples/tree/main/samples/grpc-responder), which will be used later for autoscaling.
+
+With gRPC, it's common practice to use TLS for the entire network path, we will generate one time self-signed certs.
+
+```
+mkcert grpc.keda
+kubectl create secret tls grpc-responder --cert=grpc.keda.pem --key=grpc.keda-key.pem
+```{{exec}}
+
+Now lets create the `Deployment`{{}} mounting our TLS certificate and key:
+```yaml
+cat << 'EOF' | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grpc-responder
+  namespace: default
+  labels:
+    app: grpc-responder
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grpc-responder
+  template:
+    metadata:
+      labels:
+        app: grpc-responder
+    spec:
+      containers:
+      - name: grpc-responder
+        image: ghcr.io/kedify/sample-grpc-responder
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 50051
+        env:
+        - name: RESPONSE_MESSAGE
+          value: "Hello from Kedify"
+        - name: TLS_ENABLED
+          value: "true"
+        - name: TLS_CERT_FILE
+          value: "/certs/tls.crt"
+        - name: TLS_KEY_FILE
+          value: "/certs/tls.key"
+        volumeMounts:
+        - name: certs
+          mountPath: /certs
+      volumes:
+      - name: certs
+        secret:
+          secretName: grpc-responder
+EOF
+```{{exec}}
+
+Then a `Service`{{}}:
+```yaml
+cat << 'EOF' | kubectl apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: grpc-responder
+spec:
+  selector:
+    app: grpc-responder
+  ports:
+  - protocol: TCP
+    port: 50051
+    targetPort: 50051
+  type: ClusterIP
+EOF
+```{{exec}}
+
+And finally an `Ingress`{{}}:
+```yaml
+cat << 'EOF' | kubectl apply -f -
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grpc-responder
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "GRPCS"
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - grpc.keda
+    secretName: grpc-responder
+  rules:
+  - host: grpc.keda
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: grpc-responder
+            port:
+              number: 50051
+EOF
+```{{exec}}
+
+So far these are all standard Kubernetes resources, KEDA is designed to plug into your application, your configuration, your workflow rather than force you to redesign your CI/CD pipelines.
+
+The application is configured to receive requests for the URL `https://grpc.keda`{{}}, which will work only locally in the Killercoda environment. It may take some time for the ingress controller to assign an IP address to our `Ingress`{{}}.
+
+The following snippet ensures that there is a matching entry in `/etc/hosts`{{}} so the URL `https://grpc.keda`{{}} can be resolved successfully. In a real-world scenario, you would likely either create the DNS record manually or use the external-dns project with the `Ingress`{{}} resource.
+```
+kubectl wait -ndefault --for=jsonpath='{.status.loadBalancer.ingress}' ingress/grpc-responder --timeout=5m
+IP=$(kubectl get -ndefault ingress grpc-responder -o json | jq --raw-output '.status.loadBalancer.ingress[].ip')
+echo "${IP} grpc.keda" >> /etc/hosts
+```{{exec}}
+
+Lets hit the endpoint of the appplication:
+```
+grpcurl -d '{"name": "Test"}' --authority grpc.keda grpc.keda:443 responder.HelloService/SayHello
+```{{exec}}
+
+You should see similar reponse:
+```json
+{
+  "message": "Hello from Kedify"
+}
+```{{}}
+
+You can also verify that all components of our application is running. There is a single `Deployment`{{}} with single `Pod`{{}}, `Service`{{}} and `Ingress`{{}} resources that you might expect in a standard simple backend application hosted on Kubernetes.
+```
+kubectl get deployment -ndefault grpc-responder
+```{{exec}}
+
+```
+kubectl get pod -ndefault
+```{{exec}}
+
+```
+kubectl get service -ndefault grpc-responder
+```{{exec}}
+
+```
+kubectl get ingress -ndefault grpc-responder
+```{{exec}}
+
+Well done! Now you are ready to explore gRPC autoscaling and Kedify agent autowiring.
+
+&nbsp;
+&nbsp;
+
+##### 3 / 4

--- a/killercoda/grpc/finish.md
+++ b/killercoda/grpc/finish.md
@@ -1,0 +1,1 @@
+This was a Kedify gRPC scaling tutorial, check out our other courses at [https://kedify.io/tutorials](https://kedify.io/tutorials).

--- a/killercoda/grpc/foreground.sh
+++ b/killercoda/grpc/foreground.sh
@@ -1,0 +1,6 @@
+while read -r line; do
+  echo "$line"
+  if [[ $line == "-- ready" ]]; then
+      exit 0
+  fi
+done < <(tail -f /tmp/progress)

--- a/killercoda/grpc/index.json
+++ b/killercoda/grpc/index.json
@@ -1,0 +1,43 @@
+{
+  "title": "Kedify gRPC scaling",
+  "description": "Guide on how to scale gRPC service with KEDA.",
+  "details": {
+    "intro": {
+      "text": "intro.md",
+      "foreground": "foreground.sh",
+      "background": "background.sh"
+    },
+    "finish": {
+      "text": "finish.md"
+    },
+    "assets": {
+      "host01": [
+        { "file": "init-kedify.sh", "target": "/scripts", "chmod": "+x" },
+        { "file": "init-kedify.service", "target": "/lib/systemd/system" },
+        { "file": "install-kube-deps.sh", "target": "/scripts", "chmod": "+x" },
+        { "file": "install-kube-deps.service", "target": "/lib/systemd/system" },
+        { "file": "benchmark.sh", "target": "/scripts", "chmod": "+x" }
+      ]
+    },
+    "steps": [
+      {
+        "title": "Install Kedify Agent",
+        "text": "install-kedify-agent.md",
+        "verify": "install-kedify-agent-verify.sh"
+      },
+      {
+        "title": "Deploy Sample Application",
+        "text": "deploy-sample-app.md",
+        "verify": "deploy-sample-app-verify.sh"
+      },
+      {
+        "title": "Autoscale Application",
+        "text": "autoscale.md",
+        "verify": "autoscale-verify.sh"
+      }
+    ]
+  },
+  "backend": {
+    "imageid": "kubernetes-kubeadm-1node-4GB-rapid"
+  }
+}

--- a/killercoda/grpc/install-kedify-agent-verify.sh
+++ b/killercoda/grpc/install-kedify-agent-verify.sh
@@ -1,0 +1,1 @@
+kubectl get deployment -n keda kedify-agent

--- a/killercoda/grpc/install-kedify-agent.md
+++ b/killercoda/grpc/install-kedify-agent.md
@@ -1,0 +1,41 @@
+The Kedify agent is an application designed to simplify deployment and management of KEDA seamlessly within your Kubernetes environment. For the purposes of the scenario here in Killercoda, you will use the pre-installed [Kedify kubectl plugin](https://github.com/jkremser/kubectl-kedify). You can click on the command below, it will get automatically executed in the terminal on the right part of the screen.
+```bash
+kubectl kedify install --email grpc-scaler@killercoda.com -y
+```{{exec}}
+
+The agent also enhances KEDA capabilities with additional features. In scope of this scenario, you are going to learn about the HTTP scaler with streamlined management of `Ingress`{{}} resources.
+
+> Learn more about the Kedify HTTP Scaler -> https://kedify.io/scalers/http
+
+After the agent is deployed, it will install KEDA and other necessary dependencies, you can observe all getting installed with:
+```bash
+watch -n1 --color kubecolor --force-colors get deployments -nkeda
+```{{exec}}
+
+
+Deployed KEDA should look similar to this, it may take around 1 to 2 minutes for all KEDA parts to become fully ready
+```bash
+NAME                                   READY   UP-TO-DATE   AVAILABLE   AGE
+keda-add-ons-http-controller-manager   1/1     1            1           81s
+keda-add-ons-http-external-scaler      1/1     1            1           81s
+keda-add-ons-http-interceptor          1/1     1            1           81s
+keda-admission-webhooks                1/1     1            1           83s
+keda-operator                          1/1     1            1           83s
+keda-operator-metrics-apiserver        1/1     1            1           83s
+kedify-agent                           1/1     1            1           99s
+metrics-server                         1/1     1            1           88s
+```{{}}
+
+The agent installed metrics server, latest KEDA and HTTP Add-On. To stop the `watch`{{}} loop, you can just hit:
+```
+# ctrl+c
+```{{exec interrupt}}
+
+> The official KEDA documentation is a great resource of information if you are curious to learn more about the fundamental building blocks, architecture and best practices, check out https://keda.sh/docs/2.15/concepts.
+
+When you have finished agent installation and exploring the KEDA deployments, click on the `CHECK`{{}} button on the bottom to move to the next step.
+
+&nbsp;
+&nbsp;
+
+##### 2 / 4

--- a/killercoda/grpc/intro.md
+++ b/killercoda/grpc/intro.md
@@ -1,0 +1,12 @@
+# Kedify HTTP Scaler with gRPC
+
+This tutorial will guide you through setting up Kedify HTTP Scaler with a gRPC service. Check out [our other tutorial](https://kedify.io/tutorials/http-scaler) to learn more about Kedify fundamentals.
+
+Kedify's HTTP Scaler is not only more performant than the KEDA upstream version (see the [this blog post](https://kedify.io/resources/blog/http-scaler-launch) for more details) but also more feature complete with a convenient gRPC and TLS support.
+
+And as a small bonus, Kedify also simplifies traffic routing with `Ingress`{{}} autowiring, automatically configuring `Ingress`{{}} resources to match autoscaling setups. This reduces misconfiguration risks and provides a seamless experience for managing ingress, with a safe fallback and built-in recovery mechanisms.
+
+&nbsp;
+&nbsp;
+
+##### 1 / 4

--- a/killercoda/structure.json
+++ b/killercoda/structure.json
@@ -4,6 +4,7 @@
     "image": "./assets/kedify-logo.png",
     "items": [
         { "path": "http-scaler" },
-        { "path": "gateway-api" }
+        { "path": "gateway-api" },
+        { "path": "grpc" }
     ]
 }


### PR DESCRIPTION
New tutorial on how to use Kedify HTTP Scaler to autoscale gRPC service with TLS.

For trying it out, until merged it will be available at https://killercoda.com/kedify-develop/course/killercoda/grpc. After that it will have a matching URL similar to https://github.com/kedify/examples/pull/42 and https://github.com/kedify/examples/pull/37.