### PR TITLE
examples: HTTP header based routing

### DIFF
--- a/samples/http-scaler-with-header-routing/Makefile
+++ b/samples/http-scaler-with-header-routing/Makefile
@@ -1,0 +1,16 @@
+APP_NAME := http-server
+
+.PHONY: all
+all: deploy patch-etc-hosts-file
+
+.PHONY: deploy
+deploy:
+	kubectl apply -f manifests.yaml
+
+.PHONY: patch-etc-hosts-file
+patch-etc-hosts-file:
+	@kubectl wait ingress/$(APP_NAME) --timeout=60s --for=jsonpath='{.status.loadBalancer.ingress}'
+	@kubectl wait ingress --for='jsonpath={.spec.rules[0].http.paths[0].backend.service.name}=kedify-proxy' http-server
+	@sudo sed -i.bak "/demo.keda/d" /etc/hosts
+	IP=$$(kubectl get ingress $(APP_NAME) -o jsonpath='{.status.loadBalancer.ingress[0].ip}'); \
+	echo "$${IP} demo.keda" | sudo tee -a /etc/hosts

--- a/samples/http-scaler-with-header-routing/README.md
+++ b/samples/http-scaler-with-header-routing/README.md
@@ -1,0 +1,77 @@
+# Using `kedify-http` Scaler with HTTP Headers
+
+This example demonstrates how to use the `kedify-http` scaler with HTTP headers to scale a Kubernetes deployment based on incoming HTTP requests.
+
+## Prerequisites
+- Kubernetes cluster
+- Kedify installed with addon version at least `v0.10.0-7`
+
+## Deploy Sample Application
+
+```
+make deploy
+```
+
+There is a single ingress resource created with the name `http-server` as an endpoint for the application:
+```
+$ kubectl get ingress
+NAME          CLASS     HOSTS       ADDRESS      PORTS   AGE
+http-server   traefik   demo.keda   172.18.0.2   80      21s
+```
+
+There are three versions of the same application - `http-server`, with `foo` and` bar` - and one `kedify-proxy` deployment.
+```
+$ kubectl get deployments
+NAME           READY   UP-TO-DATE   AVAILABLE   AGE
+bar            0/0     0            0           22s
+foo            0/0     0            0           22s
+http-server    0/0     0            0           22s
+kedify-proxy   1/1     1            1           21s
+```
+
+There are also three `ScaledObject` resources, one for each version of the application:
+```
+$ kubectl get so
+NAME           SCALETARGETKIND      SCALETARGETNAME   MIN   MAX   READY   ACTIVE   FALLBACK   PAUSED    TRIGGERS   AUTHENTICATIONS   AGE
+bar            apps/v1.Deployment   bar               0     5     True    False    False      Unknown                                31s
+foo            apps/v1.Deployment   foo               0     5     True    False    False      Unknown                                31s
+http-server    apps/v1.Deployment   http-server       0     5     True    False    False      Unknown                                31s
+```
+
+They all have `kedify-http` scaler defined as a trigger. The `foo` and `bar` also contain an HTTP header match condition for `app: foo` and `app: bar` respectively.
+
+## Test the Application
+For convenience, set proper entries in `/etc/hosts` file:
+```
+make patch-etc-hosts-file
+```
+This will allow you to access the application using `demo.keda` hostname.
+
+Without setting `app` header to either `foo` or `bar`, the request will be routed to `http-server` deployment:
+```
+$ curl http://demo.keda/info
+delay config:  {FixedDelay:0s IsRange:false MinDelay:0 MaxDelay:0}
+POD_NAME:      http-server-77ddd5fc5b-n47g4
+POD_NAMESPACE: default
+POD_IP:        10.42.0.39
+```
+
+With `app: foo` header, the request will be routed to `foo` deployment:
+```
+$ curl -H "app: foo" http://demo.keda/info
+delay config:  {FixedDelay:0s IsRange:false MinDelay:0 MaxDelay:0}
+POD_NAME:      foo-7d74cf8fc6-nnglk
+POD_NAMESPACE: default
+POD_IP:        10.42.0.41
+```
+
+With `app: bar` header, the request will be routed to `bar` deployment:
+```
+$ curl -H "app: bar" http://demo.keda/info
+delay config:  {FixedDelay:0s IsRange:false MinDelay:0 MaxDelay:0}
+POD_NAME:      bar-7fccc97f85-8st2n
+POD_NAMESPACE: default
+POD_IP:        10.42.0.43
+```
+
+For more information, check https://kedify.io/documentation/scalers/http-scaler/#routing-traffic-with-http-headers

--- a/samples/http-scaler-with-header-routing/manifests.yaml
+++ b/samples/http-scaler-with-header-routing/manifests.yaml
@@ -1,0 +1,251 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: http-server
+spec:
+  rules:
+    - host: demo.keda
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: http-server
+                port:
+                  number: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: http-server
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: http-server
+  template:
+    metadata:
+      labels:
+        app: http-server
+    spec:
+      containers:
+        - name: mycontainer
+          image: ghcr.io/kedify/sample-http-server:latest
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: http-server
+  namespace: default
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: http-server
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foo
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: foo
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+        - name: mycontainer
+          image: ghcr.io/kedify/sample-http-server:latest
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: foo
+  namespace: default
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: foo
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bar
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: bar
+  template:
+    metadata:
+      labels:
+        app: bar
+    spec:
+      containers:
+        - name: mycontainer
+          image: ghcr.io/kedify/sample-http-server:latest
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bar
+  namespace: default
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: bar
+  type: ClusterIP
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: http-server 
+  namespace: default
+spec:
+  maxReplicaCount: 5
+  minReplicaCount: 0
+  cooldownPeriod: 5
+  advanced:
+    restoreToOriginalReplicaCount: true
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 5
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: http-server
+  triggers:
+  - metadata:
+      # Because no header is specified, all requests that don't match foo or bar will be routed to http-server
+      hosts: demo.keda
+      pathPrefixes: /
+      port: "8080"
+      scalingMetric: requestRate
+      service: http-server
+      targetValue: "1"
+    metricType: AverageValue
+    type: kedify-http
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: foo 
+  namespace: default
+spec:
+  maxReplicaCount: 5
+  minReplicaCount: 0
+  cooldownPeriod: 5
+  advanced:                                              
+    restoreToOriginalReplicaCount: true            
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 5
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: foo
+  triggers:
+  - metadata:
+      hosts: demo.keda
+      # When request has this header, it will be routed to foo instead of http-server
+      headers: |
+        - name: app
+          value: foo
+      pathPrefixes: /
+      port: "8080"
+      scalingMetric: requestRate
+      service: foo
+      targetValue: "1"
+    metricType: AverageValue
+    type: kedify-http
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: bar 
+  namespace: default
+spec:
+  maxReplicaCount: 5
+  minReplicaCount: 0
+  cooldownPeriod: 5
+  advanced:                                              
+    restoreToOriginalReplicaCount: true            
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 5
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: bar
+  triggers:
+  - metadata:
+      hosts: demo.keda
+      # When request has this header, it will be routed to bar instead of http-server
+      headers: |
+        - name: app
+          value: bar
+      pathPrefixes: /
+      port: "8080"
+      scalingMetric: requestRate
+      service: bar
+      targetValue: "1"
+    metricType: AverageValue
+    type: kedify-http

--- a/samples/http-server/config/internal-service-autowiring.yaml
+++ b/samples/http-server/config/internal-service-autowiring.yaml
@@ -89,11 +89,8 @@ spec:
     kind: Deployment
     name: server-service
   cooldownPeriod: 5
-  minReplicaCount: 1
-  maxReplicaCount: 1
-  fallback:                                       
-    failureThreshold: 2           
-    replicas: 1
+  minReplicaCount: 0
+  maxReplicaCount: 2
   advanced:                                              
     restoreToOriginalReplicaCount: true            
     horizontalPodAutoscalerConfig:
@@ -109,6 +106,6 @@ spec:
       scalingMetric: requestRate
       targetValue: "1000"
       granularity: 1s
-      window: 10s
+      window: 60s
       trafficAutowire: service
       fallbackService: server-service-fallback

--- a/samples/http-server/config/manifests.yaml
+++ b/samples/http-server/config/manifests.yaml
@@ -23,6 +23,18 @@ spec:
           env:
             - name: RESPONSE_DELAY
               value: "0.3"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
example for using HTTP header routing with `kedify-http` scaler

https://kedify.io/documentation/scalers/http-scaler/#routing-traffic-with-http-headers


plus minor cleanup