### PR TITLE
http-server: tls delay expiration timeout

### DIFF
--- a/samples/http-server/README.md
+++ b/samples/http-server/README.md
@@ -174,7 +174,11 @@ You can run the HTTP server with TLS enabled behind the NGINX ingress controller
     value: "1.0"
   - name: TLS_WRITE_DELAY
     value: "0.5"
+  - name: TLS_DELAY_TIMEOUT
+    value: "5.0"
   ```
+
+  These variables control the delays for accepting connections, reading from the connection, writing to the connection, and the expiration timeout for these operations.
 
 4. **Test TLS with Host Header**:
 

--- a/samples/http-server/config/internal-service-autowiring-tls-buggy.yaml
+++ b/samples/http-server/config/internal-service-autowiring-tls-buggy.yaml
@@ -119,9 +119,13 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://jaeger-all-in-one.default.svc:4317
+              value: jaeger-all-in-one.default.svc:4317
             - name: RESPONSE_DELAY
               value: "0.3"
+            - name: TLS_ACCEPT_DELAY
+              value: "2.0"
+            - name: TLS_DELAY_TIMEOUT
+              value: "15.0"
             - name: TLS_ENABLED
               value: "true"
             - name: TLS_CERT_FILE


### PR DESCRIPTION
for situations where we want the TLS delay to expire after some time and application to perform well.