### PR TITLE
http-server example with named nonstandard ports

### DIFF
--- a/samples/http-server/config/internal-service-autowiring-named-ports.yaml
+++ b/samples/http-server/config/internal-service-autowiring-named-ports.yaml
@@ -1,0 +1,114 @@
+# Service internal autowiring example
+#
+# kubectl run curl --image=curlimages/curl:latest --restart=Never --command -- /bin/sh -c "sleep infinity"
+# kubectl exec -it curl -- sh 
+#
+# curl -I -H 'host: server-service.keda' http://server-service.default.svc.cluster.local:8081
+#
+# kubectl run hey --image=ghcr.io/kedacore/tests-hey:latest --restart=Never --command -- /bin/sh -c "sleep infinity"
+# kubectl exec -it hey -- sh
+#
+# ./hey -n 100000 -c 1500 -t 0 -host "server-service.keda" http://server-service.default.svc.cluster.local:8081
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: server-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: server-service
+  template:
+    metadata:
+      labels:
+        app: server-service
+    spec:
+      containers:
+        - name: server-service
+          image: ghcr.io/kedify/sample-http-server:latest
+          imagePullPolicy: Always
+          ports:
+            - name: contport
+              containerPort: 8082
+              protocol: TCP
+          env:
+            - name: PORT
+              value: "8082"
+            - name: RESPONSE_DELAY
+              value: "1-3"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: server-service
+spec:
+  ports:
+    - name: myport
+      protocol: TCP
+      port: 8081
+      targetPort: contport
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: server-service-fallback
+spec:
+  ports:
+    - name: myport
+      protocol: TCP
+      port: 8081
+      targetPort: contport
+  type: ClusterIP
+  selector:
+    app: server-service
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: server-service
+spec:
+  rules:
+    - host: server-service.keda
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: server-service
+                port:
+                  number: 8081
+---
+kind: ScaledObject
+apiVersion: keda.sh/v1alpha1
+metadata:
+  name: server-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: server-service
+  cooldownPeriod: 60
+  minReplicaCount: 1
+  maxReplicaCount: 5
+  advanced:                                              
+    restoreToOriginalReplicaCount: true            
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 30
+  triggers:
+  - type: kedify-http
+    metadata:
+      hosts: server-service.keda
+      service: server-service
+      portName: "myport"
+      scalingMetric: requestRate
+      targetValue: "1"
+      granularity: 1s
+      window: 60s
+      trafficAutowire: service
+      fallbackService: server-service-fallback
+      loadbalancing: eds

--- a/samples/http-server/main.go
+++ b/samples/http-server/main.go
@@ -212,6 +212,9 @@ func main() {
 	if tlsEnabled {
 		addr = ":8443"
 	}
+	if port := os.Getenv("PORT"); port != "" {
+		addr = ":" + port
+	}
 
 	server := &http.Server{
 		Addr:    addr,


### PR DESCRIPTION
an example where the ports are not the standard `http` and `8080`
- application has port `contport` with `8082`
- service has port `myport` with `8081`
- loadbalancing is `eds`
