### PR TITLE
sample: argo rollouts canary

### DIFF
--- a/samples/Readme.md
+++ b/samples/Readme.md
@@ -3,6 +3,7 @@ Source code for examples used in blog posts hosted at [https://www.kedify.io/blo
 
 | Directory                                  | Description                          | Used KEDA scalers                   |
 | ------------------------------------------ | ------------------------------------ | ----------------------------------- |
+| [argo-rollouts-canary](./argo-rollouts-canary) | Argo Rollouts canary deployments driven by `kedify-http`, with weighted traffic splitting handled by the Kedify Argo Rollouts traffic-router plugin | Kedify HTTP |
 | [azul-prp](./azul-prp)                     | This example demonstrates how to vertically scale a Java app running on Azul JVM | Kedify Vertical Scaling |
 | [envoy-http-scaler](./envoy-http-scaler)   | This example demonstrates how to use the already exisiting envoy to scale a deployment based on the request rate  | Kedify Envoy HTTP |
 | [grpc-responder](./grpc-responder)         | This application can be scaled by incoming gRPC traffic, including scale to zero  | Kedify HTTP |

--- a/samples/argo-rollouts-canary/Makefile
+++ b/samples/argo-rollouts-canary/Makefile
@@ -1,0 +1,25 @@
+APP_NAME := rollouts-demo
+
+.PHONY: all
+all: deploy patch-etc-hosts-file
+
+.PHONY: deploy
+deploy:
+	kubectl apply -f manifests.yaml
+
+.PHONY: patch-etc-hosts-file
+patch-etc-hosts-file:
+	@kubectl wait ingress/$(APP_NAME) --timeout=60s --for=jsonpath='{.status.loadBalancer.ingress}'
+	@kubectl wait ingress --for='jsonpath={.spec.rules[0].http.paths[0].backend.service.name}=kedify-proxy' $(APP_NAME)
+	@sudo sed -i.bak "/demo.keda/d" /etc/hosts
+	@IP=$$(kubectl get ingress $(APP_NAME) -o jsonpath='{.status.loadBalancer.ingress[0].ip}'); \
+	HOSTNAME=$$(kubectl get ingress $(APP_NAME) -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'); \
+	if [ -n "$${IP}" ]; then \
+		echo "$${IP} demo.keda" | sudo tee -a /etc/hosts; \
+	elif [ -n "$${HOSTNAME}" ]; then \
+		echo "Ingress $(APP_NAME) exposes hostname '$${HOSTNAME}' but no numeric IP. Resolve it (e.g. 'getent hosts $${HOSTNAME}') and add the result to /etc/hosts manually." >&2; \
+		exit 1; \
+	else \
+		echo "Ingress $(APP_NAME) has no loadBalancer ip or hostname yet — your Ingress controller probably hasn't assigned an external address." >&2; \
+		exit 1; \
+	fi

--- a/samples/argo-rollouts-canary/README.md
+++ b/samples/argo-rollouts-canary/README.md
@@ -1,0 +1,156 @@
+# Canary deployments with Argo Rollouts and `kedify-http`
+
+This example shows how to combine Argo Rollouts canary strategy with the
+`kedify-http` scaler. Traffic between the stable and canary versions is split
+inside the Kedify interceptor (via Envoy `weighted_clusters`), driven by an
+Argo Rollouts traffic router plugin (`kedify/http`) that patches an annotation
+on the `HTTPScaledObject`.
+
+## Prerequisites
+
+- Kubernetes cluster
+- An Ingress controller that publishes an external address on the `Ingress`
+  status (e.g. a `LoadBalancer` IP or hostname). `make patch-etc-hosts-file`
+  waits on `.status.loadBalancer.ingress[]` to be populated and won't proceed
+  without it
+- KEDA + Kedify (HTTP add-on) installed, with the Kedify agent running
+- [Argo Rollouts](https://argoproj.github.io/argo-rollouts/installation/) installed
+  with the `kedify/http` traffic router plugin loaded. The plugin ships as
+  pre-built binaries on
+  [its GitHub releases](https://github.com/kedify/argo-rollouts-plugin/releases) - 
+  copy the install snippet (with the matching `sha256` from `checksums.txt`)
+  into the `argo-rollouts-config` ConfigMap in the `argo-rollouts` namespace
+  and restart the controller
+- [`kubectl argo rollouts`](https://argoproj.github.io/argo-rollouts/installation/#kubectl-plugin-installation)
+  plugin - used below to drive the canary (`set image`, `promote`,
+  `abort`, `status`). If you'd rather not install it, you can drive the
+  Rollout via plain `kubectl patch` against the Rollout spec/status instead
+- **Cluster-admin permission** to apply the sample - `make deploy` creates a
+  `ClusterRole`/`ClusterRoleBinding` granting the Argo Rollouts controller
+  patch access to `HTTPScaledObject` resources cluster-wide
+- The sample assumes Argo Rollouts is installed in namespace `argo-rollouts`
+  and runs as the `argo-rollouts` ServiceAccount (the upstream defaults). If
+  you've installed it elsewhere, adjust the `subjects:` namespace + name in
+  `manifests.yaml` accordingly
+
+## Architecture
+
+```
+Argo Rollouts → kedify/http plugin SetWeight(N)
+   ↓ patches
+HTTPScaledObject annotation: http.kedify.io/weighted-backends
+   ↓ observed by
+Kedify interceptor → Envoy WeightedClusters {stable: 100-N%, canary: N%}
+   ↓
+kedify-proxy splits traffic between stable / canary services
+```
+
+The Argo Rollout owns the pod template, canary strategy, and service wiring.
+When the `ScaledObject` is active, KEDA/HPA manages the Rollout's replica
+count via the Rollout `/scale` subresource. The `ScaledObject` targets the
+Rollout (`apiVersion: argoproj.io/v1alpha1, kind: Rollout`) - the scaler
+resolves `stableService` / `canaryService` from the Rollout spec
+automatically, so no `service` field is required in trigger metadata.
+
+## Deploy
+
+```
+make deploy
+```
+
+This creates:
+
+- `Rollout/rollouts-demo` with stable image `argoproj/rollouts-demo:blue`, `stableService: rollouts-demo-stable`, `canaryService: rollouts-demo-canary`,
+  and explicit canary weights of 20% / 50% / 80%, then full promotion on completion
+- `Service/rollouts-demo-stable`, `Service/rollouts-demo-canary` (selector managed by Argo Rollouts)
+- `Ingress/rollouts-demo` pointing at the stable service - autowire will rewrite the backend to `kedify-proxy`
+- `ScaledObject/rollouts-demo` with a `kedify-http` trigger; no `service` is specified - the scaler auto-resolves it from the Rollout
+
+```
+$ kubectl get rollout,httpso,so
+NAME                                DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+rollout.argoproj.io/rollouts-demo   2         2         2            2           21s
+
+NAME                                          TARGETWORKLOAD   TARGETSERVICE   MINREPLICAS   MAXREPLICAS   AGE   ACTIVE
+httpscaledobject.http.keda.sh/rollouts-demo                                    2             5             20s
+
+NAME                                 SCALETARGETKIND                SCALETARGETNAME   MIN   MAX   READY   ACTIVE    FALLBACK   PAUSED   TRIGGERS      AUTHENTICATIONS   AGE
+scaledobject.keda.sh/rollouts-demo   argoproj.io/v1alpha1.Rollout   rollouts-demo     2     5     True    Unknown   False      False    kedify-http                     21s
+```
+
+## Test the application
+
+Set the host alias for `demo.keda`:
+
+```
+make patch-etc-hosts-file
+```
+
+Send some traffic. Initially everything goes to the stable (`blue`) version:
+
+```
+$ for i in {1..10}; do curl -s http://demo.keda/color; echo; done
+"blue"
+"blue"
+...
+```
+
+## Trigger a canary
+
+Switch the canary image to `yellow`:
+
+```
+kubectl argo rollouts set image rollouts-demo rollouts-demo=argoproj/rollouts-demo:yellow
+```
+
+Argo Rollouts moves to step 1 (`setWeight: 20`). The plugin patches the
+`HTTPScaledObject` annotation:
+
+```
+$ kubectl get httpso rollouts-demo -o jsonpath='{.metadata.annotations.http\.kedify\.io/weighted-backends}'
+- service: rollouts-demo-stable
+  weight: 80
+- service: rollouts-demo-canary
+  weight: 20
+```
+
+Send traffic - roughly 20% should now hit `yellow`:
+
+```
+$ for i in {1..50}; do curl -s http://demo.keda/color; echo; done | sort | uniq -c
+     41 "blue"
+      9 "yellow"
+```
+
+Continue through the remaining steps:
+
+```
+kubectl argo rollouts promote rollouts-demo
+```
+
+Watch the rollout progress with:
+
+```
+kubectl argo rollouts get rollout rollouts-demo --watch
+```
+
+When the canary fully promotes, the plugin removes the `http.kedify.io/weighted-backends` annotation and the interceptor reverts to a
+single cluster pointing at the stable service (now serving the new image).
+
+To roll back mid-canary:
+
+```
+kubectl argo rollouts abort rollouts-demo
+```
+
+## Cleanup
+
+```
+kubectl delete -f manifests.yaml
+```
+
+## Further reading
+
+- [Argo Rollouts canary strategy](https://argoproj.github.io/argo-rollouts/features/canary/)
+- [Argo Rollouts traffic management plugins](https://argoproj.github.io/argo-rollouts/features/traffic-management/plugins/)
+- Kedify Argo Rollouts plugin source: <https://github.com/kedify/argo-rollouts-plugin>

--- a/samples/argo-rollouts-canary/manifests.yaml
+++ b/samples/argo-rollouts-canary/manifests.yaml
@@ -1,0 +1,134 @@
+---
+# Grant argo-rollouts permission to patch HTTPScaledObjects so the kedify/http
+# traffic router plugin can update the http.kedify.io/weighted-backends
+# annotation.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argo-rollouts-kedify-http
+rules:
+  - apiGroups: ["http.keda.sh"]
+    resources: ["httpscaledobjects"]
+    verbs: ["get", "list", "watch", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argo-rollouts-kedify-http
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-rollouts-kedify-http
+subjects:
+  - kind: ServiceAccount
+    name: argo-rollouts
+    namespace: argo-rollouts
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: rollouts-demo
+spec:
+  rules:
+    - host: demo.keda
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: rollouts-demo-stable
+                port:
+                  number: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rollouts-demo-stable
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: rollouts-demo
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rollouts-demo-canary
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: rollouts-demo
+  type: ClusterIP
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: rollouts-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: rollouts-demo
+  template:
+    metadata:
+      labels:
+        app: rollouts-demo
+    spec:
+      containers:
+        - name: rollouts-demo
+          image: argoproj/rollouts-demo:blue
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+  strategy:
+    canary:
+      stableService: rollouts-demo-stable
+      canaryService: rollouts-demo-canary
+      trafficRouting:
+        plugins:
+          kedify/http:
+            httpScaledObjectName: rollouts-demo
+      steps:
+        - setWeight: 20
+        - pause: {}
+        - setWeight: 50
+        - pause: {duration: 30s}
+        - setWeight: 80
+        - pause: {duration: 30s}
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: rollouts-demo
+spec:
+  maxReplicaCount: 5
+  minReplicaCount: 2
+  cooldownPeriod: 5
+  advanced:
+    restoreToOriginalReplicaCount: true
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 5
+  scaleTargetRef:
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
+    name: rollouts-demo
+  triggers:
+    - metadata:
+        hosts: demo.keda
+        pathPrefixes: /
+        port: "80"
+        scalingMetric: requestRate
+        targetValue: "1000"
+        trafficAutowire: "ingress"
+      metricType: AverageValue
+      type: kedify-http


### PR DESCRIPTION
This PR demonstrates how to use `kedify-http` scaler along with argo rollouts canary feature and kedify traffic-router plugin - https://github.com/kedify/argo-rollouts-plugin.

Docs PR will followup with releases.