### PR TITLE
The example was noop (30megs -> 30 megs)

### DIFF
--- a/test-data/resources/prp.yaml
+++ b/test-data/resources/prp.yaml
@@ -18,7 +18,7 @@ spec:
         image: nginx
         resources:
           requests:
-            memory: 30M
+            memory: 50M
             cpu: 50m
           limits:
             memory: 500M
@@ -39,3 +39,4 @@ spec:
   newResources:
     requests:
       memory: 30M
+


### PR DESCRIPTION
w/ this it's 50 megs by default and after 30 seconds the requests for memory are lowered to 30 megs